### PR TITLE
Improved Locker Room Fight Story, Added New Week 0 Bless Story

### DIFF
--- a/app/src/main/java/CFBsimPack/League.java
+++ b/app/src/main/java/CFBsimPack/League.java
@@ -360,7 +360,7 @@ public class League {
                 String storyPlayer;
 
                 for(int i = 0; i < 1; i++){
-                switch((int)(Math.random() * 5)) { //Change the number Math.random is multiplied by to the number of cases (so last case # + 1)
+                switch((int)(Math.random() * 6)) { //Change the number Math.random is multiplied by to the number of cases (so last case # + 1)
                     case 0:
                         //Hired a shiny new coach who used to play for the school (feed those Vol fans wishing for Peyton something to dream on)
                         newsStories.get(0).add("Blue Chip hire for Bad Break University>" + saveBless.name + " announced the hire of alumnus and former professional coach " + getRandName() + ", today. It was long rumored that the highly touted coach considered the position a \"dream job\", but talks between the two didn't heat up until this offseason. The hire certainly helps boost the prestige of the University's football program, which has fallen on hard times as of late.");
@@ -412,7 +412,14 @@ public class League {
 
                     case 4:
                         //Inspired by that time Kliff did the stanky leg in a circle of Tech players)
-                        newsStories.get(0).add("Moves Like a Dancer from the Body of a Coach>When a cell phone recording of Coach " + storyFullName + " out dancing his players at the end of a Spring practice was uploaded to the internet, " + storyLastName + " thought nothing of it. When it hit one million views over night, Coach took notice. In response to wild popularity his moves have received, " + storyLastName + " has made it a new tradition at " + saveBless.name + " to have a dance off with all prospective recruits, much to the delight of fans and students, who have turned out in large numbers to watch the competitions.");
+                        newsStories.get(0).add("Just Call Him Coach Dougie>When a cell phone recording of Coach " + storyFullName + " out dancing his players at the end of a Spring practice was uploaded to the internet, " + storyLastName + " thought nothing of it. When it hit one million views over night, Coach took notice. In response to wild popularity his moves have received, " + storyLastName + " has made it a new tradition at " + saveBless.name + " to have a dance off with all prospective recruits, much to the delight of fans and students, who have turned out in large numbers to watch the competitions.");
+                        break;
+
+
+                    case 5:
+                        //Originally pitched as a story about the team partying hard, and getting positive recruiting as a result, before homecoming despite losing the game, I couldn't think of a good way to turn that into a preseason story directly. As a result this one is inspired by that.
+                        //And if the sarcasm/humor in this story isn't obvious, I've done something wrong
+                        newsStories.get(0).add("Breaking News: College Athletes Love Partying>A stunning development out of " + saveBless.name + " today, as it's being reported that college athletes, and athletic recruits for that matter, love to \"party and just have a good time.\" This surprising development grew out of reports on social media that " + saveBless.name + " fall practices were drawing large crowds. These stories eventually led to more reports that full fledged parties, complete with beer and music, were taking place after each practice. Recruits have been abuzz on social media declaring their intent to check out these parties and their desire to play for a school that \"knows how to have a good time.\" Coaching staffs around the country are scratching their collective heads in bewilderment while " + saveBless.name + " enjoys their sudden and unexpected recruiting boon.");
                         break;
 
 
@@ -682,7 +689,7 @@ public class League {
                         cursedWR2 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(1);
                         cursedWR3 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(2);
                     }
-                    if ((cursedQB.statsPassComp/cursedQB.statsPassAtt * 100) > 60 && cursedWR.statsTargets > cursedWR2.statsTargets && cursedWR.statsTargets > cursedWR3.statsTargets) {
+                    if (100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 60 && cursedWR.statsTargets > cursedWR2.statsTargets && cursedWR.statsTargets > cursedWR3.statsTargets) {
                         if (findTeam((saveCurse.abbr)).wins == 0) {
                             //QB and WR still in sync, but the team lost
                             newsStories.get(curseDevelopingWeek + 1).add(saveCurse.name + " Locker Room Scuffle Affects Week 1 Performance>Despite managing to find their sync after a locker room altercation last week, quarterback " + cursedQB.name + " and wide receiver " + cursedWR.name + " still left a lasting negative impression in the minds and performance of their teammates. " + cursedQB.name + "'s " + cursedQB.statsPassYards + " yards and " + cursedWR.name + "'s " + cursedWR.statsReceptions + " receptions could not bring the rest of the team out of the funk that eventually saw them drop their season opener.");
@@ -691,13 +698,28 @@ public class League {
                             newsStories.get(curseDevelopingWeek + 1).add("Water Under the Bridge at " + saveCurse.name + ">" + saveCurse.name + " didn't appear to remember the locker room altercation from last week nor the media attention it garnered as " + cursedQB.name + " threw for " + cursedQB.statsPassYards + " yards and " + cursedWR.name + " caught " + cursedWR.statsReceptions + " balls to help lift " + saveCurse.name + " in their season opener. " + cursedQB.name.replaceAll(".* ", "") + " still looked to his favorite target more than any other receiver, but all is still not perfectly well within the program.");
                         }
                     }
-                    else if(cursedQB.statsPassComp/cursedQB.statsPassAtt * 100 > 65){
+                    else if(100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 59){
                         //QB had a good game but didn't hit his old favorite more than other WRs
-                        newsStories.get(curseDevelopingWeek+1).add("Team Unrest Continues at " + saveCurse.name + ">Quarterback " + cursedQB.name + " looked good in his season opener, throwing " + cursedQB.statsPassComp + " completions for " + cursedQB.statsPassYards + " yards, primairily to receivers not named " + cursedWR.name + ". Sources within the program have remained quiet since last week's locker room scuffle between the once tight QB-WR duo, but one thing is clear: " + cursedQB.name.replaceAll(".* ","") + " has not forgotten.");
+                        newsStories.get(curseDevelopingWeek+1).add("Team Unrest Continues at " + saveCurse.name + ">Quarterback " + cursedQB.name + " looked good in his season opener, throwing " + cursedQB.statsPassComp + " completions for " + cursedQB.statsPassYards + " yards, primarily to receivers not named " + cursedWR.name + ". Sources within the program have remained quiet since last week's locker room scuffle between the once tight QB-WR duo, but one thing is clear: " + cursedQB.name.replaceAll(".* ","") + " has not forgotten.");
                     }
+                    else if(100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 44 && 100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) < 60){
+                        //QB was pretty much a non-factor
+                        String winOrLoss;
+                        if(findTeam((saveCurse.abbr)).wins == 0) winOrLoss = "loss";
+                        else winOrLoss = "win";
+
+                        newsStories.get(curseDevelopingWeek+1).add(cursedQB.name + " a Non-Factor in Season Opener>On the heels of a locker room fight that dominated national media and brought the leadership capabilities of the " + saveCurse.name + " coaching staff into question, starting quarterback " + cursedQB.name + " opened his season without much fanfare. Or much of anything. " + cursedQB.name.replaceAll(".* ","") + " threw for " + cursedQB.statsPassYards + " yards on " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " passing, managing to look perfectly average in a season opening " + winOrLoss + ".");
+                    }
+
                     else{
-                        //QB had a bad game
-                        newsStories.get(curseDevelopingWeek+1).add(cursedQB.name + " Fails to Find Rhythm in Season Opener>Just over a week after reports of a locker room fight between " + saveCurse.name + " quarterback " + cursedQB.name + " and his favorite target, wide receiver " + cursedWR.name + ", " + cursedQB.name.replaceAll(".* ","") + " looked out of sorts in his season debut. Looking visibly disoriented and confused at times, " + cursedQB.name.replaceAll(".* ","") + " failed to break a 60% completion percentage as fans were left wondering if they were watching the beginnings of a lost year of development.");
+                        //QB had a bad game and the team lost
+                        if(findTeam((saveCurse.abbr)).wins == 0){
+                            newsStories.get(curseDevelopingWeek + 1).add(cursedQB.name + " Fails to Find Rhythm in Season Opener>Just over a week after reports surfaced of a locker room fight between " + saveCurse.name + " quarterback " + cursedQB.name + " and his favorite target, wide receiver " + cursedWR.name + ", the two are back in the media spotlight for a lackluster performance in a season opening loss. Looking visibly disoriented and confused at times, " + cursedQB.name.replaceAll(".* ", "") + " went just " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " passing, and failed to achieve any consistency in a losing effort.");
+                        }
+                        else{ //QB looked crappy but the team managed to pull one out anyway
+                            newsStories.get(curseDevelopingWeek+1).add(saveCurse.name + " Manage a Win Despite Poor QB Play>Appearing to still be caught up in the locker room drama of last week, " + cursedQB.name + " had to get by with a little help from his friends. Going " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " while looking lost at times, " + cursedQB.name.replaceAll(".* ","") + "'s performance left a lot to be desired. Still, the damage done was not enough to surrender a loss, and " + saveCurse.name + " marches into Week 2 with a 1-0 record.");
+                        }
+
                     }
                 break;
 


### PR DESCRIPTION
Added/improved follow up stories for the locker room fight curse story -- The follow up stories now check for more scenarios such as did the QB have a bad game in a loss, did the QB have a good game in a loss, was the QB average, etc. and prints an appropriate story to match. I feel better about this as it felt incomplete last night but I wanted to get something posted.

Also added a new bless story for week 0. This was originally pitched as a story about the team partying hard before homecoming and losing, but still getting positive attention from recruits who wanted to live that party life. Instead of trying to make a complex setup where the schedule was checked for a random game and have that game be a loss etcetcetc, I just made a week 0 story about big parties happening at/after fall practices and how this was getting positive attention from recruits.

At this point I probably have about 2 or 3 stories left before I can consider this complete and move on to something else (probably restructuring runPlay() to have more complete clock management scenarios)
